### PR TITLE
Split out password update from the main user form

### DIFF
--- a/lib/idea_portal/accounts.ex
+++ b/lib/idea_portal/accounts.ex
@@ -79,6 +79,15 @@ defmodule IdeaPortal.Accounts do
   end
 
   @doc """
+  Update an account's password
+  """
+  def update_password(user, params) do
+    user
+    |> User.password_changeset(params)
+    |> Repo.update()
+  end
+
+  @doc """
   Validate a user's login information
   """
   def validate_login(email, password) do

--- a/lib/idea_portal/accounts/user.ex
+++ b/lib/idea_portal/accounts/user.ex
@@ -61,7 +61,6 @@ defmodule IdeaPortal.Accounts.User do
   def update_changeset(struct, params) do
     struct
     |> changeset(params)
-    |> password_changeset(params)
     |> maybe_reset_verification()
   end
 

--- a/lib/web/controllers/account_controller.ex
+++ b/lib/web/controllers/account_controller.ex
@@ -11,14 +11,29 @@ defmodule Web.AccountController do
     |> render("edit.html")
   end
 
+  def update(conn, %{"user" => params = %{"password" => _password}}) do
+    %{current_user: user} = conn.assigns
+
+    case Accounts.update_password(user, params) do
+      {:ok, _user} ->
+        conn
+        |> put_flash(:info, "Your account has been updated")
+        |> redirect(to: Routes.account_path(conn, :edit))
+
+      {:error, _changeset} ->
+        conn
+        |> put_flash(:error, "There was an issue updating your account")
+        |> redirect(to: Routes.account_path(conn, :edit))
+    end
+  end
+
   def update(conn, %{"user" => params}) do
     %{current_user: user} = conn.assigns
 
     case Accounts.update(user, params) do
-      {:ok, user} ->
+      {:ok, _user} ->
         conn
         |> put_flash(:info, "Your account has been updated")
-        |> put_session(:user_token, user.token)
         |> redirect(to: Routes.account_path(conn, :edit))
 
       {:error, changeset} ->

--- a/lib/web/templates/account/edit.html.eex
+++ b/lib/web/templates/account/edit.html.eex
@@ -1,17 +1,17 @@
+<%= if flash = get_flash(@conn, :info) do %>
+  <div class="alert alert-primary" role="alert">
+    <%= flash %>
+  </div>
+<% end %>
+<%= if flash = get_flash(@conn, :error) do %>
+  <div class="alert alert-danger" role="alert">
+    <%= flash %>
+  </div>
+<% end %>
+
 <div class="card card-form custom-card">
   <div class="card-body">
     <div class="form-titles">
-      <%= if flash = get_flash(@conn, :info) do %>
-        <div class="alert alert-primary" role="alert">
-          <%= flash %>
-        </div>
-      <% end %>
-      <%= if flash = get_flash(@conn, :error) do %>
-        <div class="alert alert-danger" role="alert">
-          <%= flash %>
-        </div>
-      <% end %>
-      
       <h2 class="title-bar font-semibold">Edit Account</h2>
 
       <%= form_for(@changeset, Routes.account_path(@conn, :update), [method: :put], fn f -> %>
@@ -45,6 +45,18 @@
           </div>
         </div>
 
+        <%= submit("Update", class: "btn btn-primary") %>
+      <% end) %>
+    </div>
+  </div>
+</div>
+
+<div class="card card-form custom-card">
+  <div class="card-body">
+    <div class="form-titles">
+      <h2 class="title-bar font-semibold">Change Password</h2>
+
+      <%= form_for(@changeset, Routes.account_path(@conn, :update), [method: :put], fn f -> %>
         <div class="row mx-md-n4">
           <div class="col-12 col-md-6 px-md-4">
             <div class="form-group form-control-material">

--- a/test/web/controllers/account_controller_test.exs
+++ b/test/web/controllers/account_controller_test.exs
@@ -1,0 +1,65 @@
+defmodule Web.AccountControllerTest do
+  use Web.ConnCase
+
+  describe "updating your information" do
+    test "success", %{conn: conn} do
+      user = TestHelpers.create_user(%{first_name: "John"})
+
+      params = %{first_name: "Joe"}
+
+      conn =
+        conn
+        |> assign(:current_user, user)
+        |> put(Routes.account_path(conn, :update), user: params)
+
+      assert redirected_to(conn) == Routes.account_path(conn, :edit)
+    end
+
+    test "failure", %{conn: conn} do
+      user = TestHelpers.create_user(%{first_name: "John"})
+
+      params = %{first_name: nil}
+
+      conn =
+        conn
+        |> assign(:current_user, user)
+        |> put(Routes.account_path(conn, :update), user: params)
+
+      assert html_response(conn, 422)
+    end
+  end
+
+  describe "updating your password" do
+    test "success", %{conn: conn} do
+      user = TestHelpers.create_user()
+
+      params = %{password: "passw0rd", password_confirmation: "passw0rd"}
+
+      conn =
+        conn
+        |> assign(:current_user, user)
+        |> put(Routes.account_path(conn, :update), user: params)
+
+      assert redirected_to(conn) == Routes.account_path(conn, :edit)
+
+      flash = Phoenix.Controller.get_flash(conn)
+      assert Map.has_key?(flash, "info")
+    end
+
+    test "failure", %{conn: conn} do
+      user = TestHelpers.create_user()
+
+      params = %{password: nil}
+
+      conn =
+        conn
+        |> assign(:current_user, user)
+        |> put(Routes.account_path(conn, :update), user: params)
+
+      assert redirected_to(conn) == Routes.account_path(conn, :edit)
+
+      flash = Phoenix.Controller.get_flash(conn)
+      assert Map.has_key?(flash, "error")
+    end
+  end
+end


### PR DESCRIPTION
To let you update the password separate and not require the password to
update your other information.

<img width="983" alt="Screen Shot 2019-03-11 at 2 55 16 PM" src="https://user-images.githubusercontent.com/449228/54149924-b39a2c80-440d-11e9-82da-487ead299d73.png">

- [ ] ~README is up to date~
- [x] Docs are up to date with changes (modules and functions)
- [x] Tests are included for changes
- [ ] ~Links in emails use the `_url` route helpers~
