### PR TITLE
User toggle participation display

### DIFF
--- a/lib/idea_portal/accounts.ex
+++ b/lib/idea_portal/accounts.ex
@@ -220,6 +220,19 @@ defmodule IdeaPortal.Accounts do
   end
 
   @doc """
+  Get a user by an ID, public view
+  """
+  def public_get(id) do
+    case Repo.get_by(User, id: id, display: true) do
+      nil ->
+        {:error, :not_found}
+
+      user ->
+        {:ok, user}
+    end
+  end
+
+  @doc """
   Find a user by a token
   """
   def get_by_token(token) do

--- a/lib/idea_portal/accounts.ex
+++ b/lib/idea_portal/accounts.ex
@@ -20,9 +20,23 @@ defmodule IdeaPortal.Accounts do
   Get all accounts
   """
   def all(opts \\ []) do
+    opts = Enum.into(opts, %{})
+
+    query = Filter.filter(User, opts[:filter], __MODULE__)
+
+    Pagination.paginate(Repo, query, %{page: opts[:page], per: opts[:per]})
+  end
+
+  @doc """
+  Get all public accounts
+  """
+  def public(opts \\ []) do
+    opts = Enum.into(opts, %{})
+
     query =
       User
       |> where([u], u.finalized == true)
+      |> where([u], u.display == true)
       |> Filter.filter(opts[:filter], __MODULE__)
 
     Pagination.paginate(Repo, query, %{page: opts[:page], per: opts[:per]})
@@ -307,5 +321,15 @@ defmodule IdeaPortal.Accounts do
       [a],
       ilike(a.first_name, ^value) or ilike(a.last_name, ^value) or ilike(a.email, ^value)
     )
+  end
+
+  @doc """
+  Toggle display status of a user
+  """
+  def toggle_display(user) do
+    user
+    |> Ecto.Changeset.change()
+    |> Ecto.Changeset.put_change(:display, !user.display)
+    |> Repo.update()
   end
 end

--- a/lib/idea_portal/accounts/user.ex
+++ b/lib/idea_portal/accounts/user.ex
@@ -16,6 +16,7 @@ defmodule IdeaPortal.Accounts.User do
   schema "users" do
     field(:role, :string, read_after_writes: true)
     field(:finalized, :boolean, default: true)
+    field(:display, :boolean, default: true)
 
     field(:email, :string)
     field(:password_hash, :string)

--- a/lib/idea_portal/teams.ex
+++ b/lib/idea_portal/teams.ex
@@ -30,7 +30,7 @@ defmodule IdeaPortal.Teams do
     query =
       Team
       |> where([t], is_nil(t.deleted_at))
-      |> preload(members: [:user])
+      |> preload(members: ^member_query())
 
     Pagination.paginate(Repo, query, opts)
   end
@@ -42,6 +42,7 @@ defmodule IdeaPortal.Teams do
     team =
       Team
       |> where([t], t.id == ^id and is_nil(t.deleted_at))
+      |> preload(members: ^member_query())
       |> Repo.one()
 
     case team do
@@ -52,6 +53,13 @@ defmodule IdeaPortal.Teams do
         team = Repo.preload(team, members: :user)
         {:ok, team}
     end
+  end
+
+  defp member_query() do
+    from m in Member,
+      join: u in assoc(m, :user),
+      where: u.display == true,
+      preload: :user
   end
 
   @doc """

--- a/lib/web/controllers/account_controller.ex
+++ b/lib/web/controllers/account_controller.ex
@@ -10,7 +10,7 @@ defmodule Web.AccountController do
   def index(conn, params) do
     %{page: page, per: per} = conn.assigns
     filter = Map.get(params, "filter", %{})
-    pagination = Accounts.all(filter: filter, page: page, per: per)
+    pagination = Accounts.public(filter: filter, page: page, per: per)
 
     conn
     |> assign(:accounts, pagination.page)

--- a/lib/web/controllers/account_controller.ex
+++ b/lib/web/controllers/account_controller.ex
@@ -19,12 +19,12 @@ defmodule Web.AccountController do
     |> render("index.html")
   end
 
-  def show(conn, params) do
-    {:ok, account} = Accounts.get(params["id"])
-
-    conn
-    |> assign(:account, account)
-    |> render("show.html")
+  def show(conn, %{"id" => id}) do
+    with {:ok, account} <- Accounts.public_get(id) do
+      conn
+      |> assign(:account, account)
+      |> render("show.html")
+    end
   end
 
   def edit(conn, _params) do

--- a/lib/web/controllers/admin/user_controller.ex
+++ b/lib/web/controllers/admin/user_controller.ex
@@ -1,0 +1,25 @@
+defmodule Web.Admin.UserController do
+  use Web, :controller
+
+  alias IdeaPortal.Accounts
+
+  plug(Web.Plugs.FetchPage when action in [:index])
+
+  def index(conn, _params) do
+    %{page: page, per: per} = conn.assigns
+    %{page: users, pagination: pagination} = Accounts.all(page: page, per: per)
+
+    conn
+    |> assign(:users, users)
+    |> assign(:pagination, pagination)
+    |> render("index.html")
+  end
+
+  def show(conn, %{"id" => id}) do
+    with {:ok, user} <- Accounts.get(id) do
+      conn
+      |> assign(:user, user)
+      |> render("show.html")
+    end
+  end
+end

--- a/lib/web/controllers/admin/user_controller.ex
+++ b/lib/web/controllers/admin/user_controller.ex
@@ -22,4 +22,13 @@ defmodule Web.Admin.UserController do
       |> render("show.html")
     end
   end
+
+  def toggle(conn, %{"id" => id}) do
+    with {:ok, user} <- Accounts.get(id),
+         {:ok, user} <- Accounts.toggle_display(user) do
+      conn
+      |> put_flash(:info, "User display updated")
+      |> redirect(to: Routes.admin_user_path(conn, :show, user.id))
+    end
+  end
 end

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -97,6 +97,8 @@ defmodule Web.Router do
     resources("/events", EventController, only: [:edit, :update, :delete])
 
     resources("/teams", TeamController, only: [:index, :show, :edit, :update, :delete])
+
+    resources("/users", UserController, only: [:index, :show])
   end
 
   if Mix.env() == :dev do

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -99,6 +99,7 @@ defmodule Web.Router do
     resources("/teams", TeamController, only: [:index, :show, :edit, :update, :delete])
 
     resources("/users", UserController, only: [:index, :show])
+    post("/users/:id/toggle", UserController, :toggle, as: :user)
   end
 
   if Mix.env() == :dev do

--- a/lib/web/templates/admin/challenge/show.html.eex
+++ b/lib/web/templates/admin/challenge/show.html.eex
@@ -40,7 +40,7 @@
             <dd><%= String.capitalize(@challenge.status) %></dd>
 
             <dt>Submitter</dt>
-            <dd><%= @challenge.user.email %></dd>
+            <dd><%= link(@challenge.user.email, to: Routes.admin_user_path(@conn, :show, @challenge.user_id)) %></dd>
 
             <dt>Name</dd>
             <dd><%= @challenge.name %></dd>

--- a/lib/web/templates/admin/team/show.html.eex
+++ b/lib/web/templates/admin/team/show.html.eex
@@ -40,7 +40,7 @@
           <h4>Members</h4>
           <ul>
             <%= Enum.map(@members, fn member -> %>
-              <li><%= member.user.email %></li>
+              <li><%= link(member.user.email, to: Routes.admin_user_path(@conn, :show, member.user_id)) %></li>
             <% end) %>
           <ul>
         </div>

--- a/lib/web/templates/admin/user/index.html.eex
+++ b/lib/web/templates/admin/user/index.html.eex
@@ -25,6 +25,7 @@
                   <th>ID</th>
                   <th>Name</th>
                   <th>Role</th>
+                  <th>Finalized?</th>
                   <th>Actions</th>
                 </tr>
               </thead>
@@ -34,6 +35,7 @@
                     <td><%= user.id %></td>
                     <td><%= link(user.first_name, to: Routes.admin_user_path(@conn, :show, user.id)) %></td>
                     <td><%= user.role %></td>
+                    <td><%= user.finalized %></td>
                     <td>
                       <%= link("View", to: Routes.admin_user_path(@conn, :show, user.id), class: "btn btn-default btn-xs") %>
                     </td>

--- a/lib/web/templates/admin/user/index.html.eex
+++ b/lib/web/templates/admin/user/index.html.eex
@@ -1,0 +1,51 @@
+<section class="content-header">
+  <h1>
+    Users
+  </h1>
+
+  <ol class="breadcrumb">
+    <li>
+      <%= link(to: Routes.admin_dashboard_path(@conn, :index)) do %>
+        <i class="fa fa-dashboard"></i> Home
+      <% end %>
+    </li>
+    <li class="active">Users</li>
+  </ol>
+</section>
+
+<section class="content">
+  <div class="row">
+    <div class="col-md-9">
+      <div class="box box-primary">
+        <div class="box-body">
+          <div class="table-responsive">
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>Name</th>
+                  <th>Role</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <%= Enum.map @users, fn (user) -> %>
+                  <tr>
+                    <td><%= user.id %></td>
+                    <td><%= link(user.first_name, to: Routes.admin_user_path(@conn, :show, user.id)) %></td>
+                    <td><%= user.role %></td>
+                    <td>
+                      <%= link("View", to: Routes.admin_user_path(@conn, :show, user.id), class: "btn btn-default btn-xs") %>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+
+          <%= SharedView.pagination(path: Routes.admin_user_path(@conn, :index), pagination: @pagination) %>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/lib/web/templates/admin/user/show.html.eex
+++ b/lib/web/templates/admin/user/show.html.eex
@@ -20,6 +20,13 @@
       <div class="box box-primary">
         <div class="box-header">
           <h3 class="box-title">Basics</h3>
+          <div class="box-tools">
+            <%= if @user.display do %>
+              <%= link("Hide participation", to: Routes.admin_user_path(@conn, :toggle, @user.id), method: :post, class: "btn btn-default") %>
+            <% else %>
+              <%= link("Show participation", to: Routes.admin_user_path(@conn, :toggle, @user.id), method: :post, class: "btn btn-default") %>
+            <% end %>
+          </div>
         </div>
         <div class="box-body">
           <dl>

--- a/lib/web/templates/admin/user/show.html.eex
+++ b/lib/web/templates/admin/user/show.html.eex
@@ -1,0 +1,45 @@
+<section class="content-header">
+  <h1>
+    <%= AccountView.full_name(@user) %>
+  </h1>
+
+  <ol class="breadcrumb">
+    <li>
+      <%= link(to: Routes.admin_dashboard_path(@conn, :index)) do %>
+        <i class="fa fa-dashboard"></i> Home
+      <% end %>
+    </li>
+    <li><%= link("Challenges", to: Routes.admin_user_path(@conn, :index)) %></li>
+    <li class="active"><%= AccountView.full_name(@user) %></li>
+  </ol>
+</section>
+
+<section class="content">
+  <div class="row">
+    <div class="col-md-offset-3 col-md-6">
+      <div class="box box-primary">
+        <div class="box-header">
+          <h3 class="box-title">Basics</h3>
+        </div>
+        <div class="box-body">
+          <dl>
+            <dt>Name</dd>
+            <dd><%= AccountView.full_name(@user) %></dd>
+
+            <dt>Phone Number</dd>
+            <dd><%= phone_number(@user) %></dd>
+
+            <dt>Email</dd>
+            <dd><%= @user.email %></dd>
+
+            <dt>Role</dd>
+            <dd><%= @user.role %></dd>
+
+            <dt>Verified email?</dt>
+            <dd><%= email_verified?(@user) %></dd>
+          </dl>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/lib/web/templates/layout/admin.html.eex
+++ b/lib/web/templates/layout/admin.html.eex
@@ -51,6 +51,12 @@
                 <span>Teams</span>
               <% end %>
             </li>
+            <li class="<%= tab_selected(@conn, "users") %>">
+              <%= link(to: Routes.admin_user_path(@conn, :index)) do %>
+                <i class="fa fa-user"></i>
+                <span>Users</span>
+              <% end %>
+            </li>
           </ul>
         </section>
       </aside>

--- a/lib/web/templates/layout/app.html.eex
+++ b/lib/web/templates/layout/app.html.eex
@@ -11,7 +11,7 @@
           <div class="content-left left-menu-wrapper">
             <div class="menu-close"><a href="javascript:;"><i class="icon-close-custom"></i></a></div>
             <div class="logo side-nav-logo">
-              <img src="images/logo.png" alt="City Backlog Logo" title="City Backlog">
+              <img src="<%= Routes.static_path(@conn, "/images/logo.png") %>" alt="City Backlog Logo" title="City Backlog">
             </div>
             <div class="side-nav font-semibold">
               <ul class="mp-none">

--- a/lib/web/templates/team/_invite_member.html.eex
+++ b/lib/web/templates/team/_invite_member.html.eex
@@ -29,7 +29,7 @@
             <div class="card participant-item">
               <div class="card-body">
                 <a href="javascript:;" class="text-center">
-                  <span class="image-circle"><img src="images/participant.png" alt=""></span>
+                  <span class="image-circle"><!-- <img src="images/participant.png" alt=""> --></span>
                   <h3 class="font-regular">Member Name</h3>
                 </a>
                 <div class="participant-close-icon-modal">

--- a/lib/web/views/admin/user_view.ex
+++ b/lib/web/views/admin/user_view.ex
@@ -1,0 +1,20 @@
+defmodule Web.Admin.UserView do
+  use Web, :view
+
+  alias Web.AccountView
+  alias Web.SharedView
+
+  def phone_number(%{phone_number: nil}), do: "Not Provided"
+
+  def phone_number(user), do: user.phone_number
+
+  def email_verified?(user) do
+    case is_nil(user.email_verified_at) do
+      true ->
+        "Not verified"
+
+      false ->
+        "Verified"
+    end
+  end
+end

--- a/priv/repo/migrations/20190607135753_add_display_to_users.exs
+++ b/priv/repo/migrations/20190607135753_add_display_to_users.exs
@@ -1,0 +1,9 @@
+defmodule IdeaPortal.Repo.Migrations.AddDisplayToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add(:display, :boolean, default: true, null: false)
+    end
+  end
+end

--- a/test/web/controllers/account_controller_test.exs
+++ b/test/web/controllers/account_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule Web.AccountControllerTest do
   use Web.ConnCase
 
+  alias IdeaPortal.Accounts
+
   describe "updating your information" do
     test "success", %{conn: conn} do
       user = TestHelpers.create_user(%{first_name: "John"})
@@ -119,7 +121,9 @@ defmodule Web.AccountControllerTest do
 
       assert html_response(conn, 200)
     end
+  end
 
+  describe "viewing a participant" do
     test "viewing an account", %{conn: conn} do
       user = TestHelpers.create_user(%{email: "current_user@example.com"})
       viewed_user = TestHelpers.create_user(%{email: "viewed_user@example.com"})
@@ -130,6 +134,19 @@ defmodule Web.AccountControllerTest do
         |> get(Routes.account_path(conn, :show, viewed_user.id))
 
       assert html_response(conn, 200)
+    end
+
+    test "cannot view a hidden account", %{conn: conn} do
+      user = TestHelpers.create_user(%{email: "current_user@example.com"})
+      viewed_user = TestHelpers.create_user(%{email: "viewed_user@example.com"})
+      {:ok, viewed_user} = Accounts.toggle_display(viewed_user)
+
+      conn =
+        conn
+        |> assign(:current_user, user)
+        |> get(Routes.account_path(conn, :show, viewed_user.id))
+
+      assert html_response(conn, 404)
     end
   end
 end


### PR DESCRIPTION
Adds a new field to toggle display on the site for a user. If display is false, they won't show in the participation listings or on a team as a member.

- [x] Docs are up to date with changes (modules and functions)
- [x] Tests are included for changes
