### PR TITLE
Admin challenge creation, submitter info, emailing

### DIFF
--- a/lib/idea_portal/challenges/challenge.ex
+++ b/lib/idea_portal/challenges/challenge.ex
@@ -45,6 +45,13 @@ defmodule IdeaPortal.Challenges.Challenge do
     field(:champion_name, :string)
     field(:champion_email, :string)
 
+    field(:submitter_first_name, :string)
+    field(:submitter_last_name, :string)
+    field(:submitter_email, :string)
+    field(:submitter_phone, :string)
+
+    field(:notes, :string)
+
     belongs_to(:user, User)
 
     has_many(:events, Event)
@@ -63,10 +70,9 @@ defmodule IdeaPortal.Challenges.Challenge do
   """
   def statuses(), do: @statuses
 
-  def create_changeset(struct, params) do
+  def create_changeset(struct, params, user) do
     struct
     |> cast(params, [
-      :captured_on,
       :focus_area,
       :name,
       :description,
@@ -75,6 +81,10 @@ defmodule IdeaPortal.Challenges.Challenge do
       :technology_example,
       :neighborhood
     ])
+    |> put_change(:submitter_first_name, user.first_name)
+    |> put_change(:submitter_last_name, user.last_name)
+    |> put_change(:submitter_email, user.email)
+    |> put_change(:submitter_phone, user.phone_number)
     |> put_change(:captured_on, Date.utc_today())
     |> validate_required([
       :captured_on,
@@ -102,7 +112,12 @@ defmodule IdeaPortal.Challenges.Challenge do
       :technology_example,
       :neighborhood,
       :champion_name,
-      :champion_email
+      :champion_email,
+      :submitter_first_name,
+      :submitter_last_name,
+      :submitter_email,
+      :submitter_phone,
+      :notes
     ])
     |> validate_required([
       :status,
@@ -117,6 +132,19 @@ defmodule IdeaPortal.Challenges.Challenge do
     |> validate_inclusion(:focus_area, @focus_areas)
     |> validate_inclusion(:status, @statuses)
     |> validate_format(:champion_email, ~r/.+@.+\..+/)
+  end
+
+  def admin_changeset(struct, params, user) do
+    struct
+    |> create_changeset(params, user)
+    |> cast(params, [
+      :captured_on,
+      :submitter_first_name,
+      :submitter_last_name,
+      :submitter_email,
+      :submitter_phone,
+      :notes
+    ])
   end
 
   def publish_changeset(struct) do

--- a/lib/idea_portal/emails.ex
+++ b/lib/idea_portal/emails.ex
@@ -51,6 +51,17 @@ defmodule IdeaPortal.Emails do
     |> render("password-reset.html")
   end
 
+  @doc """
+  Send an email about a new challenge being created
+  """
+  def new_challenge(challenge) do
+    base_email()
+    |> to("challenges@hackbaltimore.io")
+    |> subject("City Backlog - New Challenge")
+    |> assign(:challenge, challenge)
+    |> render("new-challenge.html")
+  end
+
   def base_email() do
     new_email()
     |> from(Mailer.from())

--- a/lib/web/controllers/admin/challenge_controller.ex
+++ b/lib/web/controllers/admin/challenge_controller.ex
@@ -29,6 +29,31 @@ defmodule Web.Admin.ChallengeController do
     end
   end
 
+  def new(conn, _params) do
+    %{current_user: user} = conn.assigns
+
+    conn
+    |> assign(:changeset, Challenges.admin_new(user))
+    |> render("new.html")
+  end
+
+  def create(conn, %{"challenge" => params}) do
+    %{current_user: user} = conn.assigns
+
+    case Challenges.create(user, params) do
+      {:ok, challenge} ->
+        conn
+        |> put_flash(:info, "Challenge created!")
+        |> redirect(to: Routes.admin_challenge_path(conn, :show, challenge.id))
+
+      {:error, changeset} ->
+        conn
+        |> assign(:changeset, changeset)
+        |> put_status(422)
+        |> render("new.html")
+    end
+  end
+
   def edit(conn, %{"id" => id}) do
     with {:ok, challenge} <- Challenges.get(id) do
       conn

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -93,7 +93,9 @@ defmodule Web.Router do
 
     resources("/documents", DocumentController, only: [:delete])
 
-    resources("/challenges", ChallengeController, only: [:index, :show, :edit, :update]) do
+    resources("/challenges", ChallengeController,
+      only: [:index, :show, :new, :create, :edit, :update]
+    ) do
       resources("/documents", DocumentController, only: [:create])
 
       resources("/events", EventController, only: [:new, :create])

--- a/lib/web/templates/admin/challenge/_form.html.eex
+++ b/lib/web/templates/admin/challenge/_form.html.eex
@@ -1,0 +1,55 @@
+<%= form_for(@changeset, @path, [class: "form-horizontal"], fn f -> %>
+  <div class="box-body">
+    <div class="<%= FormView.form_group_classes(f, :focus_area) %>">
+      <%= label(f, :focus_area, class: "col-md-4") do %>
+        Focus Area <span class="required">*</span>
+      <% end %>
+      <div class="col-md-8">
+        <%= select(f, :focus_area, Challenges.focus_areas(), class: "form-control") %>
+      </div>
+    </div>
+
+    <div class="<%= FormView.form_group_classes(f, :status) %>">
+      <%= label(f, :status, class: "col-md-4") do %>
+        Status <span class="required">*</span>
+      <% end %>
+      <div class="col-md-8">
+        <%= select(f, :status, Challenges.statuses(), class: "form-control") %>
+      </div>
+    </div>
+
+    <%= FormView.text_field(f, :captured_on) do %>
+      <span class="help-block">Format <code>YYYY-MM-DD</code></span>
+    <% end %>
+
+    <%= FormView.text_field(f, :name, required: true) %>
+
+    <%= FormView.textarea_field(f, :description, label: "What is the problem?", rows: 10, required: true) %>
+
+    <%= FormView.textarea_field(f, :why, label: "Why is this a problem?", rows: 10, required: true) %>
+
+    <%= FormView.textarea_field(f, :fixed_looks_like, label: "What does \"fixed\" look like?", rows: 10, required: true) %>
+
+    <%= FormView.textarea_field(f, :technology_example, label: "How does technology help solve this problem?", rows: 10, required: true) %>
+
+    <%= FormView.text_field(f, :neighborhood, label: "Location or Neighborhood") %>
+
+    <%= FormView.text_field(f, :champion_name) %>
+
+    <%= FormView.text_field(f, :champion_email) %>
+
+    <%= FormView.text_field(f, :submitter_first_name) %>
+
+    <%= FormView.text_field(f, :submitter_last_name) %>
+
+    <%= FormView.text_field(f, :submitter_email) %>
+
+    <%= FormView.text_field(f, :submitter_phone) %>
+
+    <%= FormView.textarea_field(f, :notes, label: "Notes", rows: 10) %>
+  </div>
+
+  <div class="box-footer">
+    <%= submit("Submit", class: "btn btn-primary pull-right") %>
+  </div>
+<% end) %>

--- a/lib/web/templates/admin/challenge/index.html.eex
+++ b/lib/web/templates/admin/challenge/index.html.eex
@@ -1,6 +1,7 @@
 <section class="content-header">
   <h1>
     Challenges
+    <%= link "New", to: Routes.admin_challenge_path(@conn, :new), class: "btn btn-primary" %>
   </h1>
 
   <ol class="breadcrumb">

--- a/lib/web/templates/admin/challenge/new.html.eex
+++ b/lib/web/templates/admin/challenge/new.html.eex
@@ -1,6 +1,6 @@
 <section class="content-header">
   <h1>
-    Edit Challenge #<%= @challenge.id %>
+    New Challenge 
   </h1>
 
   <ol class="breadcrumb">
@@ -10,8 +10,7 @@
       <% end %>
     </li>
     <li><%= link("Challenges", to: Routes.admin_challenge_path(@conn, :index)) %></li>
-    <li><%= link("Challenge ##{@challenge.id}", to: Routes.admin_challenge_path(@conn, :show, @challenge.id)) %></li>
-    <li class="active">Edit</li>
+    <li class="active">New</li>
   </ol>
 </section>
 
@@ -23,7 +22,7 @@
           <h3 class="box-title">Edit</h3>
         </div>
 
-        <%= render Web.Admin.ChallengeView, "_form.html", changeset: @changeset, path: Routes.admin_challenge_path(@conn, :update, @challenge.id) %>
+        <%= render Web.Admin.ChallengeView, "_form.html", changeset: @changeset, path: Routes.admin_challenge_path(@conn, :create) %>
 
       </div>
     </div>

--- a/lib/web/templates/admin/challenge/show.html.eex
+++ b/lib/web/templates/admin/challenge/show.html.eex
@@ -56,6 +56,15 @@
 
             <dt>Champion Email</dd>
             <dd><%= @challenge.champion_email %></dd>
+
+            <dt>Submitter Name</dd>
+            <dd><%= @challenge.submitter_first_name %> <%= @challenge.submitter_last_name %></dd>
+
+            <dt>Submitter Email</dd>
+            <dd><%= @challenge.submitter_email %></dd>
+
+            <dt>Submitter Phone</dd>
+            <dd><%= @challenge.submitter_phone %></dd>
           </dl>
         </div>
       </div>
@@ -182,6 +191,19 @@
               </li>
             <% end) %>
           </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-offset-3 col-md-6">
+      <div class="box box-primary">
+        <div class="box-header">
+          <h3 class="box-title">Notes</h3>
+        </div>
+        <div class="box-body">
+          <p><%= @challenge.notes %></p>
         </div>
       </div>
     </div>

--- a/lib/web/templates/email/new-challenge.html.eex
+++ b/lib/web/templates/email/new-challenge.html.eex
@@ -1,1 +1,1 @@
-<p>A new challenge has been created: <%= link("##{@challenge.id} #{@challenge.name}", to: Routes.admin_challenge_path(Endpoint, :show, @challenge.id)) %></p>
+<p>A new challenge has been created: <%= link("##{@challenge.id} #{@challenge.name}", to: Routes.admin_challenge_url(Endpoint, :show, @challenge.id)) %></p>

--- a/lib/web/templates/email/new-challenge.html.eex
+++ b/lib/web/templates/email/new-challenge.html.eex
@@ -1,0 +1,1 @@
+<p>A new challenge has been created: <%= link("##{@challenge.id} #{@challenge.name}", to: Routes.admin_challenge_path(Endpoint, :show, @challenge.id)) %></p>

--- a/priv/repo/migrations/20190730143901_add_admin_notes_to_challenges.exs
+++ b/priv/repo/migrations/20190730143901_add_admin_notes_to_challenges.exs
@@ -1,0 +1,9 @@
+defmodule IdeaPortal.Repo.Migrations.AddAdminNotesToChallenges do
+  use Ecto.Migration
+
+  def change do
+    alter table(:challenges) do
+      add(:notes, :text)
+    end
+  end
+end

--- a/priv/repo/migrations/20190730164747_add_submitter_info_to_challenge.exs
+++ b/priv/repo/migrations/20190730164747_add_submitter_info_to_challenge.exs
@@ -1,0 +1,12 @@
+defmodule IdeaPortal.Repo.Migrations.AddSubmitterInfoToChallenge do
+  use Ecto.Migration
+
+  def change do
+    alter table(:challenges) do
+      add(:submitter_first_name, :text)
+      add(:submitter_last_name, :text)
+      add(:submitter_email, :text)
+      add(:submitter_phone, :text)
+    end
+  end
+end

--- a/test/idea_portal/challenges/challenge_test.exs
+++ b/test/idea_portal/challenges/challenge_test.exs
@@ -1,19 +1,58 @@
 defmodule IdeaPortal.Challenges.ChallengeTest do
   use ExUnit.Case
+  use IdeaPortal.DataCase
 
   alias IdeaPortal.Challenges.Challenge
 
   describe "create validations" do
     test "focus area must be in the list" do
-      changeset = Challenge.create_changeset(%Challenge{}, %{focus_area: "Housing"})
+      user = TestHelpers.create_user()
+      user = TestHelpers.verify_email(user)
+
+      changeset = Challenge.create_changeset(%Challenge{}, %{focus_area: "Housing"}, user)
       refute changeset.errors[:focus_area]
 
-      changeset = Challenge.create_changeset(%Challenge{}, %{focus_area: "Other"})
+      changeset = Challenge.create_changeset(%Challenge{}, %{focus_area: "Other"}, user)
       assert changeset.errors[:focus_area]
     end
 
+    test "sets submitter first name automatically" do
+      user = TestHelpers.create_user()
+      user = TestHelpers.verify_email(user)
+
+      changeset = Challenge.create_changeset(%Challenge{}, %{}, user)
+      assert changeset.changes[:submitter_first_name]
+    end
+
+    test "sets submitter last name automatically" do
+      user = TestHelpers.create_user()
+      user = TestHelpers.verify_email(user)
+
+      changeset = Challenge.create_changeset(%Challenge{}, %{}, user)
+      assert changeset.changes[:submitter_last_name]
+    end
+
+    test "sets submitter email automatically" do
+      user = TestHelpers.create_user()
+      user = TestHelpers.verify_email(user)
+
+      changeset = Challenge.create_changeset(%Challenge{}, %{}, user)
+      assert changeset.changes[:submitter_email]
+    end
+
+    test "sets submitter phone number automatically" do
+      user = TestHelpers.create_user()
+      user = TestHelpers.verify_email(user)
+
+      changeset = Challenge.create_changeset(%Challenge{}, %{}, user)
+      assert changeset.changes[:submitter_phone]
+    end
+
     test "sets captured_on automatically" do
-      changeset = Challenge.create_changeset(%Challenge{}, %{})
+      user = TestHelpers.create_user()
+      user = TestHelpers.verify_email(user)
+
+      changeset = Challenge.create_changeset(%Challenge{}, %{}, user)
       assert changeset.changes[:captured_on]
     end
   end

--- a/test/idea_portal/challenges_test.exs
+++ b/test/idea_portal/challenges_test.exs
@@ -1,8 +1,10 @@
 defmodule IdeaPortal.ChallengesTest do
   use IdeaPortal.DataCase
+  use Bamboo.Test
 
   alias IdeaPortal.Challenges
   alias IdeaPortal.Challenges.Challenge
+  alias IdeaPortal.Emails
 
   doctest Challenges
 
@@ -34,6 +36,13 @@ defmodule IdeaPortal.ChallengesTest do
         })
 
       assert changeset.errors[:focus_area]
+    end
+
+    test "sends an email" do
+      user = TestHelpers.create_verified_user()
+      challenge = TestHelpers.create_challenge(user)
+
+      assert_delivered_email(Emails.new_challenge(challenge))
     end
 
     test "attaching supporting documents" do


### PR DESCRIPTION
* Admins can now create challenges from the admin view
* Record submitter name, email, and phone. These fields can be updated
* Admins can add admin only notes to challenges
* Send an email to hackbaltimore when a new challenge is submitted

- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
